### PR TITLE
Better examples, better memory handling

### DIFF
--- a/examples/DrawSprites/DrawSprites.ino
+++ b/examples/DrawSprites/DrawSprites.ino
@@ -10,15 +10,15 @@ const uint8_t LEDMATRIX_CS_PIN = 9;
 // Define LED Matrix dimensions (0-n) - eg: 32x8 = 31x7
 const int LEDMATRIX_WIDTH = 31;  
 const int LEDMATRIX_HEIGHT = 7;
+const int LEDMATRIX_SEGMENTS = 1;
 
 // The LEDMatrixDriver class instance
-LEDMatrixDriver *lmd = NULL;
+LEDMatrixDriver lmd(LEDMATRIX_SEGMENTS, LEDMATRIX_CS_PIN);
 
 void setup() {
   // init the display
-  lmd = new LEDMatrixDriver(4, LEDMATRIX_CS_PIN);
-  lmd->setEnabled(true);
-  lmd->setIntensity(2);   // 0 = low, 10 = high
+  lmd.setEnabled(true);
+  lmd.setIntensity(2);   // 0 = low, 10 = high
 }
 
 int x=-1, y=0;   // start top left
@@ -84,32 +84,32 @@ const int ANIM_DELAY = 100;
 void loop() {
 
   drawSprite( (byte*)&a, x++, 0, 8, 8 );
-  lmd->display();
+  lmd.display();
   delay(ANIM_DELAY);
 
-  lmd->clear();
+  lmd.clear();
   drawSprite( (byte*)&b, x++, 0, 8, 8 );
-  lmd->display();
+  lmd.display();
   delay(ANIM_DELAY);
 
-  lmd->clear();
+  lmd.clear();
   drawSprite( (byte*)&c, x++, 0, 8, 8 );
-  lmd->display();
+  lmd.display();
   delay(ANIM_DELAY);
 
-  lmd->clear();
+  lmd.clear();
   drawSprite( (byte*)&d, x++, 0, 8, 8 );
-  lmd->display();
+  lmd.display();
   delay(ANIM_DELAY);
 
-  lmd->clear();
+  lmd.clear();
   drawSprite( (byte*)&e, x++, 0, 8, 8 );
-  lmd->display();
+  lmd.display();
   delay(ANIM_DELAY);
 
-  lmd->clear();
+  lmd.clear();
   drawSprite( (byte*)&f, x++, 0, 8, 8 );
-  lmd->display();
+  lmd.display();
   delay(ANIM_DELAY);
 
   if( x > LEDMATRIX_WIDTH )
@@ -123,7 +123,7 @@ void drawSprite( byte* sprite, int x, int y, int width, int height )
   {
     for( int ix = 0; ix < width; ix++ )
     {
-      lmd->setPixel(x + ix, y + iy, (bool)(sprite[iy] & mask ));
+      lmd.setPixel(x + ix, y + iy, (bool)(sprite[iy] & mask ));
       mask = mask >> 1;
     }
     mask = B10000000;

--- a/examples/MarqueeText/MarqueeText.ino
+++ b/examples/MarqueeText/MarqueeText.ino
@@ -8,18 +8,17 @@
 const uint8_t LEDMATRIX_CS_PIN = 9;
 
 // Define LED Matrix dimensions (0-n) - eg: 32x8 = 31x7
-const int LEDMATRIX_SEGMENTS = 4;
 const int LEDMATRIX_WIDTH = 31;  
 const int LEDMATRIX_HEIGHT = 7;
+const int LEDMATRIX_SEGMENTS = 1;
 
 // The LEDMatrixDriver class instance
-LEDMatrixDriver *lmd = NULL;
+LEDMatrixDriver lmd(LEDMATRIX_SEGMENTS, LEDMATRIX_CS_PIN);
 
 void setup() {
   // init the display
-  lmd = new LEDMatrixDriver(LEDMATRIX_SEGMENTS, LEDMATRIX_CS_PIN);
-  lmd->setEnabled(true);
-  lmd->setIntensity(2);   // 0 = low, 10 = high
+  lmd.setEnabled(true);
+  lmd.setIntensity(2);   // 0 = low, 10 = high
 }
 
 int x=0, y=0;   // start top left
@@ -99,10 +98,10 @@ void loop()
 {
  // Draw the text to the current position
  drawString(text, len, x, 0);
-   // In case you wonder why we don't have to call lmd->clear() in every loop: The font has a opaque (black) background...
+   // In case you wonder why we don't have to call lmd.clear() in every loop: The font has a opaque (black) background...
  
  // Toggle display of the new framebuffer
- lmd->display();
+ lmd.display();
 
  // Wait to let the human read the display
  delay(ANIM_DELAY);
@@ -144,7 +143,7 @@ void drawSprite( byte* sprite, int x, int y, int width, int height )
   {
     for( int ix = 0; ix < width; ix++ )
     {
-      lmd->setPixel(x + ix, y + iy, (bool)(sprite[iy] & mask ));
+      lmd.setPixel(x + ix, y + iy, (bool)(sprite[iy] & mask ));
 
       // shift the mask by one pixel to the right
       mask = mask >> 1;

--- a/examples/SetPixel/SetPixel.ino
+++ b/examples/SetPixel/SetPixel.ino
@@ -10,9 +10,10 @@ const uint8_t LEDMATRIX_CS_PIN = 9;
 // Define LED Matrix dimensions (0-n) - eg: 32x8 = 31x7
 const int LEDMATRIX_WIDTH = 7;  
 const int LEDMATRIX_HEIGHT = 7;
+const int LEDMATRIX_SEGMENTS = 1;
 
 // The LEDMatrixDriver class instance
-LEDMatrixDrive lmd(4, LEDMATRIX_CS_PIN);
+LEDMatrixDriver lmd(LEDMATRIX_SEGMENTS, LEDMATRIX_CS_PIN);
 
 void setup() {
   // init the display

--- a/src/LEDMatrixDriver.cpp
+++ b/src/LEDMatrixDriver.cpp
@@ -120,25 +120,15 @@ void LEDMatrixDriver::scroll( scrollDirection direction )
 	switch( direction )
 	{
 		case scrollDirection::scrollUp:
-			cnt = 7*(N);
-			memcpy(frameBuffer, frameBuffer + N, cnt);
+			cnt = 7*(N);	// moving 7 rows of N segments
+			memmove(frameBuffer, frameBuffer + N, cnt);
 			memset(frameBuffer+cnt, 0, N);		// Clear last row
 			break;
 			
 		case scrollDirection::scrollDown:
-			cnt = 7*N;
-			
-			// Scrolling down requires a buffer  (memcpy would read the memory it just copied)
-			buf = new uint8_t[cnt];
-			
-			memcpy(buf, frameBuffer, cnt);
-			memcpy(frameBuffer+N, buf, cnt);
-			
+			cnt = 7*N; // moving 7 rows of N segments
+			memmove(frameBuffer+N, frameBuffer, cnt);
 			memset(frameBuffer, 0, N);		// Clear first row
-			
-			// clean up
-			delete[] buf;
-			
 			break;
 			
 		case scrollDirection::scrollRight:
@@ -155,7 +145,7 @@ void LEDMatrixDriver::scroll( scrollDirection direction )
 			
 		case scrollDirection::scrollLeft:
 			// Scrolling left needs to be done by bit shifting every uint8_t in the frame buffer
-			// Bits that overlap need to be carried to the next cell in a row
+			// Bits that overlap need to be carried to the prev cell in a row
 			for( int i = 0; i < 8*N; i++ )
 			{
 				uint8_t n = frameBuffer[i] & B10000000;


### PR DESCRIPTION
Examples do not use dynamic allocation anymore.
The scrolling functions use memmove instead of memcpy.