### PR TITLE
Support for 7-segment displays.

### DIFF
--- a/examples/seven-segment/seven-segment.ino
+++ b/examples/seven-segment/seven-segment.ino
@@ -1,0 +1,52 @@
+#include <LEDMatrixDriver.hpp>
+
+// This sketch how to use 7-segment displays with the LEDMatrixDriver library.
+// Example written 2017-09-30 by Søren Thing, https://github.com/Sthing.
+
+// Define the ChipSelect pin for the led matrix (Dont use the SS or MISO pin of your Arduino!)
+// Other pins are arduino specific SPI pins (MOSI=DIN of the LEDMatrix and CLK) see https://www.arduino.cc/en/Reference/SPI
+const uint8_t LEDMATRIX_CS_PIN = 9;
+
+const int NO_OF_DRIVERS = 1; // Each MAX7219 driver can drive eight 7-segment displays.
+
+// The LEDMatrixDriver class instance
+LEDMatrixDriver lmd(NO_OF_DRIVERS, LEDMATRIX_CS_PIN);
+
+void setup() {
+  // init the display
+  lmd.setEnabled(true);
+  lmd.setIntensity(2);  // 0 = min, 15 = max
+  lmd.setScanLimit(7);  // 0-7: Show 1-8 digits. Beware of currenct restrictions for 1-3 digits! See datasheet.
+  lmd.setDecode(0xFF);  // Enable "BCD Type B" decoding for all digits.
+}
+
+void loop() {
+  // Show runtime in seconds for one second
+  unsigned long now = millis();
+  byte digit;
+  do {
+    // My display has the digits in reverse order
+    // Ie digit 0 is the one on the far right.
+    // This matches 10^0 :-)
+    unsigned long rest = millis();
+    for (digit = 0; digit < 8; digit++) {
+      lmd.setDigit(digit, rest % 10, digit == 3);
+      rest /= 10;
+    }
+    lmd.display(); 
+    delay(10);
+  }
+  while (millis() - now < 1000);
+
+  // Show "- HELP -" for one second
+  lmd.setDigit(7, LEDMatrixDriver::BCD_DASH);
+  lmd.setDigit(6, LEDMatrixDriver::BCD_BLANK);
+  lmd.setDigit(5, LEDMatrixDriver::BCD_H);
+  lmd.setDigit(4, LEDMatrixDriver::BCD_E);
+  lmd.setDigit(3, LEDMatrixDriver::BCD_L);
+  lmd.setDigit(2, LEDMatrixDriver::BCD_P);
+  lmd.setDigit(1, LEDMatrixDriver::BCD_BLANK);
+  lmd.setDigit(0, LEDMatrixDriver::BCD_DASH);
+  lmd.display(); 
+  delay(1000);
+}

--- a/src/LEDMatrixDriver.hpp
+++ b/src/LEDMatrixDriver.hpp
@@ -50,6 +50,11 @@ class LEDMatrixDriver
 		uint8_t getSegments() const {return N;}
 		uint8_t* getFrameBuffer() const {return frameBuffer;}
 
+		//functions for 7-segment displays
+		void setScanLimit(uint8_t level);
+		void setDecode(uint8_t mask);
+		void setDigit(uint16_t digit, uint8_t value, bool dot = false);
+
 		//flush the data to the display
 		void display();
 		//flush a single row to the display
@@ -67,6 +72,14 @@ class LEDMatrixDriver
 		
 		//scroll the framebuffer 1 pixel in the given direction
 		void scroll( scrollDirection direction );
+
+		// BCD Code B values
+		const static uint8_t BCD_DASH =     0x0A;
+		const static uint8_t BCD_E =        0x0B;
+		const static uint8_t BCD_H =        0x0C;
+		const static uint8_t BCD_L =        0x0D;
+		const static uint8_t BCD_P =        0x0E;
+		const static uint8_t BCD_BLANK =    0x0F;
 
 	private:
 		void _sendCommand(uint16_t command);


### PR DESCRIPTION
Hi Bartosz,

Thank you for the library.

I am using it to control 7-segment displays like these:
 - [8-digit complete board](https://www.aliexpress.com/item/MAX7219-CWG-8-Digit-Digital-Tube-Display-Control-Module-Red-Three-IO-for/32815741807.html?spm=a2g0s.9042311.0.0.t2ISFz)
 - [6-digit clock display](https://www.aliexpress.com/item/0-36inch-6digits-red-clock-7-segment-led-display-3662AS-3662BS-10pcs/32793418781.html?spm=a2g0s.9042311.0.0.BL67Qr)

This pull request adds three new functions (and an example):
 - void setScanLimit(uint8_t level);
    Useful when the display has less than 8 digits.
 - void setDecode(uint8_t mask);
    Makes it really easy to display numbers on the 7-segment displays.
 - void setDigit(uint16_t digit, uint8_t value, bool dot = false);
    Makes it possible to set a single digit in the frameBuffer.

I hope you find it useful.

Best regards, Søren.