### PR TITLE
Standardize the headers in the examples and simplify configuration

### DIFF
--- a/examples/DrawSprites/DrawSprites.ino
+++ b/examples/DrawSprites/DrawSprites.ino
@@ -4,13 +4,12 @@
 // Example written 16.06.2017 by Marko Oette, www.oette.info 
 
 // Define the ChipSelect pin for the led matrix (Dont use the SS or MISO pin of your Arduino!)
-// Other pins are arduino specific SPI pins (MOSI=DIN of the LEDMatrix and CLK) see https://www.arduino.cc/en/Reference/SPI
+// Other pins are Arduino specific SPI pins (MOSI=DIN, SCK=CLK of the LEDMatrix) see https://www.arduino.cc/en/Reference/SPI
 const uint8_t LEDMATRIX_CS_PIN = 9;
 
-// Define LED Matrix dimensions (0-n) - eg: 32x8 = 31x7
-const int LEDMATRIX_WIDTH = 31;  
-const int LEDMATRIX_HEIGHT = 7;
-const int LEDMATRIX_SEGMENTS = 1;
+// Number of 8x8 segments you are connecting
+const int LEDMATRIX_SEGMENTS = 4;
+const int LEDMATRIX_WIDTH    = LEDMATRIX_SEGMENTS * 8;
 
 // The LEDMatrixDriver class instance
 LEDMatrixDriver lmd(LEDMATRIX_SEGMENTS, LEDMATRIX_CS_PIN);

--- a/examples/DrawSprites/DrawSprites.ino
+++ b/examples/DrawSprites/DrawSprites.ino
@@ -1,7 +1,7 @@
 #include <LEDMatrixDriver.hpp>
 
 // This draw a moving sprite on your LED matrix using the hardware SPI driver Library by Bartosz Bielawski.
-// Example written 16.06.2017 by Marko Oette, www.oette.info 
+// Example written 16.06.2017 by Marko Oette, www.oette.info
 
 // Define the ChipSelect pin for the led matrix (Dont use the SS or MISO pin of your Arduino!)
 // Other pins are Arduino specific SPI pins (MOSI=DIN, SCK=CLK of the LEDMatrix) see https://www.arduino.cc/en/Reference/SPI

--- a/examples/FrameBuffer_Scrolling/FrameBuffer_Scrolling.ino
+++ b/examples/FrameBuffer_Scrolling/FrameBuffer_Scrolling.ino
@@ -1,7 +1,7 @@
 #include <LEDMatrixDriver.hpp>
 
 // This draw a moving point on your LED matrix and use the scrolling feature of the hardware SPI driver Library by Bartosz Bielawski.
-// Example written 19.06.2017 by Marko Oette, www.oette.info 
+// Example written 19.06.2017 by Marko Oette, www.oette.info
 
 // Define the ChipSelect pin for the led matrix (Dont use the SS or MISO pin of your Arduino!)
 // Other pins are Arduino specific SPI pins (MOSI=DIN, SCK=CLK of the LEDMatrix) see https://www.arduino.cc/en/Reference/SPI
@@ -15,15 +15,14 @@ const int LEDMATRIX_WIDTH    = LEDMATRIX_SEGMENTS * 8;
 LEDMatrixDriver lmd(LEDMATRIX_SEGMENTS, LEDMATRIX_CS_PIN);
 
 void setup() {
-  // init the display
-  lmd.setEnabled(true);
-  lmd.setIntensity(2);   // 0 = low, 10 = high
+	// init the display
+	lmd.setEnabled(true);
+	lmd.setIntensity(2);   // 0 = low, 10 = high
 }
-
 
 const int ANIM_DELAY = 200;
 int x = 0, s = 1, dir = 0, c = 0;
-void loop() 
+void loop()
 {
   switch( dir )
   {
@@ -42,7 +41,7 @@ void loop()
     case 3:
       lmd.scroll(LEDMatrixDriver::scrollDirection::scrollRight);
       lmd.setPixel(0,x,true);
-      break;   
+      break;
   };
 
   // Show the content of the frame buffer
@@ -62,14 +61,13 @@ void loop()
     // Also clearing the buffer gives a better look to this example.
     lmd.clear();
   }
- 
+
   // Move the pixel up and down
   x += s;
   if( x == 7 )
     s = -1;
   else if( x == 0 )
     s = +1;
-     
-  delay(ANIM_DELAY);  
-  
+
+  delay(ANIM_DELAY);
 }

--- a/examples/FrameBuffer_Scrolling/FrameBuffer_Scrolling.ino
+++ b/examples/FrameBuffer_Scrolling/FrameBuffer_Scrolling.ino
@@ -4,13 +4,12 @@
 // Example written 19.06.2017 by Marko Oette, www.oette.info 
 
 // Define the ChipSelect pin for the led matrix (Dont use the SS or MISO pin of your Arduino!)
-// Other pins are arduino specific SPI pins (MOSI=DIN of the LEDMatrix and CLK) see https://www.arduino.cc/en/Reference/SPI
+// Other pins are Arduino specific SPI pins (MOSI=DIN, SCK=CLK of the LEDMatrix) see https://www.arduino.cc/en/Reference/SPI
 const uint8_t LEDMATRIX_CS_PIN = 9;
 
-// Define LED Matrix dimensions (0-n) - eg: 32x8 = 31x7
-const int LEDMATRIX_WIDTH = 7;  
-const int LEDMATRIX_HEIGHT = 7;
-const int LEDMATRIX_SEGMENTS = 1;
+// Number of 8x8 segments you are connecting
+const int LEDMATRIX_SEGMENTS = 4;
+const int LEDMATRIX_WIDTH    = LEDMATRIX_SEGMENTS * 8;
 
 // The LEDMatrixDriver class instance
 LEDMatrixDriver lmd(LEDMATRIX_SEGMENTS, LEDMATRIX_CS_PIN);

--- a/examples/MarqueeText/MarqueeText.ino
+++ b/examples/MarqueeText/MarqueeText.ino
@@ -7,19 +7,18 @@
 // Other pins are Arduino specific SPI pins (MOSI=DIN, SCK=CLK of the LEDMatrix) see https://www.arduino.cc/en/Reference/SPI
 const uint8_t LEDMATRIX_CS_PIN = 9;
 
-// Define LED Matrix dimensions: 32x8, 16x8, or 8x8
-const int LEDMATRIX_WIDTH    = 32;
-const int LEDMATRIX_HEIGHT   = 8;
-const int LEDMATRIX_SEGMENTS = LEDMATRIX_WIDTH / LEDMATRIX_HEIGHT;
+// Number of 8x8 segments you are connecting
+const int LEDMATRIX_SEGMENTS = 4;
+const int LEDMATRIX_WIDTH    = LEDMATRIX_SEGMENTS * 8;
+
+// The LEDMatrixDriver class instance
+LEDMatrixDriver lmd(LEDMATRIX_SEGMENTS, LEDMATRIX_CS_PIN);
 
 // Marquee text
 char text[] = "** LED MATRIX DEMO! ** (1234567890) ++ \"ABCDEFGHIJKLMNOPQRSTUVWXYZ\" ++ <$%/=?'.@,> --";
 
 // Marquee speed (lower nubmers = faster)
 const int ANIM_DELAY = 30;
-
-// The LEDMatrixDriver class instance
-LEDMatrixDriver lmd(LEDMATRIX_SEGMENTS, LEDMATRIX_CS_PIN);
 
 void setup() {
   // init the display

--- a/examples/SetPixel/SetPixel.ino
+++ b/examples/SetPixel/SetPixel.ino
@@ -1,7 +1,7 @@
 #include <LEDMatrixDriver.hpp>
 
 // This sketch will 'flood fill' your LED matrix using the hardware SPI driver Library by Bartosz Bielawski.
-// Example written 16.06.2017 by Marko Oette, www.oette.info 
+// Example written 16.06.2017 by Marko Oette, www.oette.info
 
 // Define the ChipSelect pin for the led matrix (Dont use the SS or MISO pin of your Arduino!)
 // Other pins are Arduino specific SPI pins (MOSI=DIN, SCK=CLK of the LEDMatrix) see https://www.arduino.cc/en/Reference/SPI
@@ -15,9 +15,9 @@ const int LEDMATRIX_WIDTH    = LEDMATRIX_SEGMENTS * 8;
 LEDMatrixDriver lmd(LEDMATRIX_SEGMENTS, LEDMATRIX_CS_PIN);
 
 void setup() {
-  // init the display
-  lmd.setEnabled(true);
-  lmd.setIntensity(2);   // 0 = low, 10 = high
+	// init the display
+	lmd.setEnabled(true);
+	lmd.setIntensity(2);   // 0 = low, 10 = high
 }
 
 int x=0, y=0;   // start top left

--- a/examples/SetPixel/SetPixel.ino
+++ b/examples/SetPixel/SetPixel.ino
@@ -4,13 +4,12 @@
 // Example written 16.06.2017 by Marko Oette, www.oette.info 
 
 // Define the ChipSelect pin for the led matrix (Dont use the SS or MISO pin of your Arduino!)
-// Other pins are arduino specific SPI pins (MOSI=DIN of the LEDMatrix and CLK) see https://www.arduino.cc/en/Reference/SPI
+// Other pins are Arduino specific SPI pins (MOSI=DIN, SCK=CLK of the LEDMatrix) see https://www.arduino.cc/en/Reference/SPI
 const uint8_t LEDMATRIX_CS_PIN = 9;
 
-// Define LED Matrix dimensions (0-n) - eg: 32x8 = 31x7
-const int LEDMATRIX_WIDTH = 7;  
-const int LEDMATRIX_HEIGHT = 7;
-const int LEDMATRIX_SEGMENTS = 1;
+// Number of 8x8 segments you are connecting
+const int LEDMATRIX_SEGMENTS = 4;
+const int LEDMATRIX_WIDTH    = LEDMATRIX_SEGMENTS * 8;
 
 // The LEDMatrixDriver class instance
 LEDMatrixDriver lmd(LEDMATRIX_SEGMENTS, LEDMATRIX_CS_PIN);
@@ -25,27 +24,26 @@ int x=0, y=0;   // start top left
 bool s = true;  // start with led on
 
 void loop() {
+	// toggle current pixel in framebuffer
+	lmd.setPixel(x, y, s);
 
-  // toggle current pixel in framebuffer
-  lmd.setPixel(x, y, s);
+	// move to next pixel
+	if( x++ >= LEDMATRIX_WIDTH )
+	{
+		// Return to left
+		x=0;
 
-  // move to next pixel
-  if( x++ >= LEDMATRIX_WIDTH )
-  {
-    // Return to left
-    x=0;
-    
-    // start new line
-    if( y++ >= LEDMATRIX_HEIGHT )
-    {
-      y = 0;  // need to return to start
-      s = !s; // toggle led state
-    }
-  }
- 
-  
-  // Flush framebuffer
-  lmd.display();
-  
-  delay(10);
+		// start new line
+		if( y++ >= 8)
+		{
+			y = 0;  // need to return to start
+			s = !s; // toggle led state
+		}
+	}
+
+
+	// Flush framebuffer
+	lmd.display();
+
+	delay(10);
 }

--- a/examples/seven-segment/seven-segment.ino
+++ b/examples/seven-segment/seven-segment.ino
@@ -33,7 +33,7 @@ void loop() {
       lmd.setDigit(digit, rest % 10, digit == 3);
       rest /= 10;
     }
-    lmd.display(); 
+    lmd.display();
     delay(10);
   }
   while (millis() - now < 1000);
@@ -47,6 +47,6 @@ void loop() {
   lmd.setDigit(2, LEDMatrixDriver::BCD_P);
   lmd.setDigit(1, LEDMatrixDriver::BCD_BLANK);
   lmd.setDigit(0, LEDMatrixDriver::BCD_DASH);
-  lmd.display(); 
+  lmd.display();
   delay(1000);
 }

--- a/examples/seven-segment/seven-segment.ino
+++ b/examples/seven-segment/seven-segment.ino
@@ -4,7 +4,7 @@
 // Example written 2017-09-30 by Søren Thing, https://github.com/Sthing.
 
 // Define the ChipSelect pin for the led matrix (Dont use the SS or MISO pin of your Arduino!)
-// Other pins are arduino specific SPI pins (MOSI=DIN of the LEDMatrix and CLK) see https://www.arduino.cc/en/Reference/SPI
+// Other pins are Arduino specific SPI pins (MOSI=DIN, SCK=CLK of the LEDMatrix) see https://www.arduino.cc/en/Reference/SPI
 const uint8_t LEDMATRIX_CS_PIN = 9;
 
 const int NO_OF_DRIVERS = 1; // Each MAX7219 driver can drive eight 7-segment displays.


### PR DESCRIPTION
Standardize the headers in the examples and simplify configuration. Also includes white-space clean up so things are cleaner.