### PR TITLE
Add the reverse_display option to each example

### DIFF
--- a/examples/DrawSprites/DrawSprites.ino
+++ b/examples/DrawSprites/DrawSprites.ino
@@ -11,8 +11,11 @@ const uint8_t LEDMATRIX_CS_PIN = 9;
 const int LEDMATRIX_SEGMENTS = 4;
 const int LEDMATRIX_WIDTH    = LEDMATRIX_SEGMENTS * 8;
 
+// If your display is backwards (left to right) and jumbled set this to true
+bool reverse_display = false;
+
 // The LEDMatrixDriver class instance
-LEDMatrixDriver lmd(LEDMATRIX_SEGMENTS, LEDMATRIX_CS_PIN);
+LEDMatrixDriver lmd(LEDMATRIX_SEGMENTS, LEDMATRIX_CS_PIN, reverse_display);
 
 void setup() {
   // init the display

--- a/examples/DrawSprites/Makefile
+++ b/examples/DrawSprites/Makefile
@@ -1,0 +1,1 @@
+/home/bakers/github/Arduino-Makefile/Makefile

--- a/examples/FrameBuffer_Scrolling/FrameBuffer_Scrolling.ino
+++ b/examples/FrameBuffer_Scrolling/FrameBuffer_Scrolling.ino
@@ -11,8 +11,11 @@ const uint8_t LEDMATRIX_CS_PIN = 9;
 const int LEDMATRIX_SEGMENTS = 4;
 const int LEDMATRIX_WIDTH    = LEDMATRIX_SEGMENTS * 8;
 
+// If your display is backwards (left to right) and jumbled set this to true
+bool reverse_display = false;
+
 // The LEDMatrixDriver class instance
-LEDMatrixDriver lmd(LEDMATRIX_SEGMENTS, LEDMATRIX_CS_PIN);
+LEDMatrixDriver lmd(LEDMATRIX_SEGMENTS, LEDMATRIX_CS_PIN, reverse_display);
 
 void setup() {
 	// init the display

--- a/examples/MarqueeText/MarqueeText.ino
+++ b/examples/MarqueeText/MarqueeText.ino
@@ -11,8 +11,11 @@ const uint8_t LEDMATRIX_CS_PIN = 9;
 const int LEDMATRIX_SEGMENTS = 4;
 const int LEDMATRIX_WIDTH    = LEDMATRIX_SEGMENTS * 8;
 
+// If your display is backwards (left to right) and jumbled set this to true
+bool reverse_display = false;
+
 // The LEDMatrixDriver class instance
-LEDMatrixDriver lmd(LEDMATRIX_SEGMENTS, LEDMATRIX_CS_PIN);
+LEDMatrixDriver lmd(LEDMATRIX_SEGMENTS, LEDMATRIX_CS_PIN, reverse_display);
 
 // Marquee text
 char text[] = "** LED MATRIX DEMO! ** (1234567890) ++ \"ABCDEFGHIJKLMNOPQRSTUVWXYZ\" ++ <$%/=?'.@,> --";

--- a/examples/MarqueeTextClean/MarqueeTextClean.ino
+++ b/examples/MarqueeTextClean/MarqueeTextClean.ino
@@ -208,15 +208,19 @@ byte font[191][5] = {
 // Define the ChipSelect pin for the led matrix (Dont use the SS or MISO pin of your Arduino!)
 // Other pins are Arduino specific SPI pins (MOSI=DIN, SCK=CLK of the LEDMatrix) see https://www.arduino.cc/en/Reference/SPI
 const uint8_t LEDMATRIX_CS_PIN = 9;
+
+// Number of 8x8 segments you are connecting
 const int LEDMATRIX_SEGMENTS = 4;
 const int LEDMATRIX_WIDTH    = LEDMATRIX_SEGMENTS * 8;
 
-//module reverse is set to true, remove the boolean parameter if
-//scrolling is appearing from the wrong side in each module.
-LEDMatrixDriver lmd(LEDMATRIX_SEGMENTS, LEDMATRIX_CS_PIN, true);
+// If your display is backwards (left to right) and jumbled set this to true
+bool reverse_display = false;
+
+// The LEDMatrixDriver class instance
+LEDMatrixDriver lmd(LEDMATRIX_SEGMENTS, LEDMATRIX_CS_PIN, reverse_display);
 
 // set x to LEDMATRIX_WIDTH to bring text "into" the display.
-int x = LEDMATRIX_WIDTH, y = 0; 
+int x = LEDMATRIX_WIDTH, y = 0;
 uint32_t scrollTimerStamp = 0;
 
 const int CHAR_WIDTH = sizeof(font[0]);
@@ -242,7 +246,7 @@ void setup() {
 
 void loop()
 {
-  // using a 
+  // using a
   if (millis() < scrollTimerStamp)
     return;
 
@@ -325,13 +329,13 @@ int getCharWidth(byte asc)
     }
     //give extra spacing for .
     if (asc == 14)
-      c_Width++;  
-  
+      c_Width++;
+
     return c_Width;
   }
 }
 
-// calculates the text width using variable character width and CHAR_SPACING and 
+// calculates the text width using variable character width and CHAR_SPACING and
 int getTextWidth(char* text)
 {
   int t_Width = 0;

--- a/examples/SetPixel/SetPixel.ino
+++ b/examples/SetPixel/SetPixel.ino
@@ -11,8 +11,11 @@ const uint8_t LEDMATRIX_CS_PIN = 9;
 const int LEDMATRIX_SEGMENTS = 4;
 const int LEDMATRIX_WIDTH    = LEDMATRIX_SEGMENTS * 8;
 
+// If your display is backwards (left to right) and jumbled set this to true
+bool reverse_display = false;
+
 // The LEDMatrixDriver class instance
-LEDMatrixDriver lmd(LEDMATRIX_SEGMENTS, LEDMATRIX_CS_PIN);
+LEDMatrixDriver lmd(LEDMATRIX_SEGMENTS, LEDMATRIX_CS_PIN, reverse_display);
 
 void setup() {
 	// init the display


### PR DESCRIPTION
I also converted the line endings on MarqueeTextClean to unix to be consistent with all the others. It *looks* like a huge change but it's just the line endings. Best viewed with `git diff -w`