### PR TITLE
Make setColumn() a lot simpler and actually work.

### DIFF
--- a/src/LEDMatrixDriver.cpp
+++ b/src/LEDMatrixDriver.cpp
@@ -73,13 +73,12 @@ bool LEDMatrixDriver::getPixel(int16_t x, int16_t y) const
 	return *p & (1 << b);
 }
 
-void LEDMatrixDriver::setColumn(int16_t x, uint8_t value)
-{	
+void LEDMatrixDriver::setColumn(int16_t x, bool value)
+{
 	//no need to check x, will be checked by setPixel
-	for (uint8_t y = 0; y < 8; ++y)
+	for (uint8_t y = 0; y < 8; y++)
 	{
-		setPixel(x, y, value & 1);
-		value >>= 1;
+		setPixel(x, y, value);
 	}
 }
 

--- a/src/LEDMatrixDriver.hpp
+++ b/src/LEDMatrixDriver.hpp
@@ -64,7 +64,7 @@ class LEDMatrixDriver
 		void setIntensity(uint8_t level);
 		void setPixel(int16_t x, int16_t y, bool enabled);
 		bool getPixel(int16_t x, int16_t y) const;
-		void setColumn(int16_t x, uint8_t value);
+		void setColumn(int16_t x, bool value);
 		uint8_t getSegments() const {return N;}
 		uint8_t* getFrameBuffer() const {return frameBuffer;}
 


### PR DESCRIPTION
I'm not sure what the bitshift was trying to do, but it does not work. This drastically simplifies this call and also makes it possible to draw a straight column (it was completely bjorked before).